### PR TITLE
honourPact takes an optional name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,7 +215,7 @@ module.exports = Mocha.interfaces['bdd'] = function (suite) {
         fn = null
       }
 
-      var test = new Test('should honour interactions', function (done) {
+      var test = new Test(opts.name || 'honours interactions', function (done) {
         wrapper.verifyPacts(opts)
           .then(function (data) {
             fn(data, done)

--- a/test/provider.spec.js
+++ b/test/provider.spec.js
@@ -28,4 +28,8 @@ PactProvider(PactOpts, function () {
     done()
   })
 
+  honourPact(Object.assign({name: 'honours a particular set of interactions'}, pactOpts), function (result, done) {
+    done()
+  })
+
 })


### PR DESCRIPTION
This allows users to provide contextualised names for test reporting if desired.

Thoughts?
