### PR TITLE
Modified verify() so that it works with already-parsed JSON

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,8 +199,8 @@ module.exports = Mocha.interfaces['bdd'] = function (suite) {
 
       var test = new Test(title, function (done) {
         clientRequestFn()
-          .then(pactSuite.pact.verify)
           .then(function (data) {
+            pactSuite.pact.verify(data);
             fn(data, done)
           })
           .catch(done)


### PR DESCRIPTION
The current implementation only works if the client request function being tested returns the raw HTTP response, not if it returns already-parsed JSON (see demo here: https://github.com/mbrowne/pact-js-client-demo/blob/master/src/App.js#L9).

With the code modification here, `pactSuite.pact.verify()` will work either way - with the raw response or with already-parsed JSON.

This offers more flexibility and I think it's important to support the use case of already-parsed JSON - in many apps, the data fetching functions used by the UI return objects rather than raw JSON strings.